### PR TITLE
Updated README.md examples to use clojure 1.4 style tagged literals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,29 @@ ordered provides sets and maps that maintain the insertion order of their conten
     (use 'ordered.set)
 
     (ordered-set 4 3 1 8 2)
-    => #{4 3 1 8 2}
+    => #ordered/set (4 3 1 8 2)
 
     (conj (ordered-set 9 10) 1 2 3)
-    => #{9 10 1 2 3}
+    => #ordered/set (9 10 1 2 3)
 
     (into (ordered-set) [7 6 1 5 6])
-    => #{7 6 1 5}
+    => #ordered/set (7 6 1 5)
 
     (disj (ordered-set 8 1 7 2 6) 7)
-    => #{8 1 2 6}
+    => #ordered/set (8 1 2 6)
 
 ## Maps
 
-    (use 'ordered.maps)
+    (use 'ordered.map)
 
     (ordered-map :b 2 :a 1 :d 4)
-    => {:b 2 :a 1 :d 3}
+    => #ordered/map ([:b 2] [:a 1] [:d 4])
 
     (assoc (ordered-map :b 2 :a 1 :d 4) :c 3)
-    => {:b 2 :a 1 :d 4 :c 3}
+    => #ordered/map ([:b 2] [:a 1] [:d 4] [:c 3])
 
     (into (ordered-map) [[:c 3] [:a 1] [:d 4]])
-    => {:c 3 :a 1 :d 4}
+    => #ordered/map ([:c 3] [:a 1] [:d 4])
 
     (dissoc (ordered-map :c 3 :a 1 :d 4) :a)
-    => {:c 3 :d 4}
+    => #ordered/map ([:c 3] [:d 4])


### PR DESCRIPTION
Thanks for the great lib. I noticed a typo in README.md and after investigation realized it needed updating for clojure 1.4 as well. Cheers - Jon.
