### PR TITLE
fix hashCode for ordered-map

### DIFF
--- a/src/ordered/map.clj
+++ b/src/ordered/map.clj
@@ -71,7 +71,7 @@
     (.equiv this other))
   (hashCode [this]
     (reduce (fn [acc ^MapEntry e]
-              (let [k (.key e), v (.val ^MapEntry (.val e))]
+              (let [k (.key e), v (.val e)]
                 (unchecked-add ^Integer acc ^Integer (bit-xor (hash k) (hash v)))))
             0 (.seq this)))
   IPersistentMap

--- a/test/ordered/map_test.clj
+++ b/test/ordered/map_test.clj
@@ -57,7 +57,10 @@
             unsorted {1 2 3 4}]
         (is (= one-way other-way))
         (is (= one-way unsorted))
-        (is (= other-way unsorted))))))
+        (is (= other-way unsorted))))
+    (testing "Hash code sanity"
+      (is (integer? (hash one-item)))
+      (is (= #{one-item} (into #{} [one-item {1 2}]))))))
 
 (deftest ordering
   (let [values [[:first 10]


### PR DESCRIPTION
Noticed the problem when I tried to put an ordered-map into a set.
