### PR TITLE
AOTCs the ordered types to allow for top-level use

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Pure-clojure implementation of ruby's ordered hash and set types - instead of sorting by key, these collections retain insertion order."
   :dependencies [[org.clojure/clojure "1.4.0"]]
+  :aot [ordered.map ordered.set]
   ;; Not required except for benchmarks.
   :profiles {:dev {:dependencies [[ordered-collections "0.4.2"]]}})


### PR DESCRIPTION
See this gist to understand why this is needed:
 https://gist.github.com/3660304

You can reproduce the error by cloning the gist and running `lein compile`.  `AOTC`ing the types seemed like the only solution but I would love to be proved wrong.
