### PR TITLE
Type hint toArray to fix JDK11 compatibility

### DIFF
--- a/src/flatland/ordered/set.clj
+++ b/src/flatland/ordered/set.clj
@@ -79,7 +79,7 @@
     (.count this))
   (isEmpty [this]
     (zero? (.count this)))
-  (toArray [this dest]
+  (^objects toArray [this ^objects dest]
     (reduce (fn [idx item]
               (aset dest idx item)
               (inc idx))


### PR DESCRIPTION
On JDK11, `toArray` needs to be hinted (see [openjdk change](https://bugs.openjdk.java.net/browse/JDK-8060192?focusedCommentId=14194092&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel)).

See [CRRBV-18](https://dev.clojure.org/jira/browse/CRRBV-18) for the core.rrb-vector fix, and [CLJ-2374](https://dev.clojure.org/jira/browse/CLJ-2374) for the same issue in clojure.