### PR TITLE
Small fixes for ordered map equiv and equals methods

### DIFF
--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -50,6 +50,7 @@
   IPersistentMap
   (equiv [this other]
     (and (instance? Map other)
+         (or (not (map? other)) (instance? MapEquivalence other))
          (= (.count this) (.size ^Map other))
          (every? (fn [^MapEntry e]
                    (let [k (.key e)]
@@ -85,7 +86,13 @@
   (toString [this]
     (str "{" (s/join ", " (for [[k v] this] (str k " " v))) "}"))
   (equals [this other]
-    (.equiv this other))
+    (and (instance? Map other)
+         (= (.count this) (.size ^Map other))
+         (every? (fn [^MapEntry e]
+                   (let [k (.key e)]
+                     (and (.containsKey ^Map other k)
+                          (.equals (.val e) (.get ^Map other k)))))
+                 (.seq this))))
   (hashCode [this]
     (APersistentMap/mapHash this))
   IHashEq


### PR DESCRIPTION
There are test cases added that fail without these changes.  (=
ordered-map some-record-with-same-keys) returns true without these
changes, for example, whereas Clojure's built-in maps are never = to
any record, by design, since records are distinct types.

(.equals ordered-map something-else) currently uses = to compare
corresponding values in the maps, but other Clojure persistent maps
use .equals to compare corresponding values.