### PR TITLE
Update readme: Clojars link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![lein dependency](https://clojars.org/org.flatland/ordered/latest-version.svg)
+[![lein dependency](https://clojars.org/org.flatland/ordered/latest-version.svg)](https://clojars.org/org.flatland/ordered)
 [![Build Status](https://travis-ci.org/clj-commons/ordered.svg?branch=develop)](https://travis-ci.org/clj-commons/ordered)
 
 ordered provides sets and maps that maintain the insertion order of their contents.


### PR DESCRIPTION
The svg at the top of the readme which shows the Clojars version should actually link to Clojars :)