### PR TITLE
More cleanup: drop support for Clojure < 1.6 (merge after #52)

### DIFF
--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -11,7 +11,6 @@
                          IHashEq
                          IObj
                          IFn
-                         Seqable
                          MapEquivalence
                          Reversible
                          MapEntry
@@ -21,16 +20,6 @@
            (java.util Map Map$Entry)))
 
 (set! *warn-on-reflection* true)
-
-;; We could use compile-if technique here, but hoping to avoid
-;; an AOT issue using this way instead.
-(def hasheq-ordered-map
-  (or (resolve 'clojure.core/hash-unordered-coll)
-      (fn old-hasheq-ordered-map [^Seqable m]
-        (reduce (fn [acc ^MapEntry e]
-                  (let [k (.key e), v (.val e)]
-                    (unchecked-add ^Integer acc ^Integer (bit-xor (hash k) (hash v)))))
-                0 (.seq m)))))
 
 (defn entry [k v i]
   (MapEntry. k (MapEntry. i v)))
@@ -134,7 +123,7 @@
     (APersistentMap/mapHash this))
   IHashEq
   (hasheq [this]
-    (hasheq-ordered-map this))
+    (hash-unordered-coll this))
 
   IObj
   (meta [this]

--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -21,6 +21,8 @@
                          )
            (java.util Map Map$Entry)))
 
+(set! *warn-on-reflection* true)
+
 ;; We could use compile-if technique here, but hoping to avoid
 ;; an AOT issue using this way instead.
 (def hasheq-ordered-map
@@ -110,13 +112,13 @@
 
   Map
   (size [this]
-    (.size backing-map))
+    (.size ^Map backing-map))
   (containsKey [this k]
     (.containsKey backing-map k))
   (isEmpty [this]
-    (.isEmpty backing-map))
+    (.isEmpty ^Map backing-map))
   (keySet [this]
-    (.keySet backing-map))
+    (.keySet ^Map backing-map))
   (get [this k]
     (.valAt this k))
   (containsValue [this v]

--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -1,10 +1,9 @@
 (ns flatland.ordered.map
-  (:use [flatland.ordered.common :only [change! Compactable compact]]
-        [flatland.ordered.set :only [ordered-set]])
+  (:require [flatland.ordered.common :refer [change! Compactable compact]]
+            [flatland.ordered.set :refer [ordered-set]])
   (:require [clojure.string :as s])
   (:import (clojure.lang APersistentMap
                          IPersistentMap
-                         IPersistentCollection
                          IPersistentVector
                          IEditableCollection
                          ITransientMap


### PR DESCRIPTION
This drops support for Clojure versions below 1.6. I think that's not unreasonable since that version is already more than 6 years old.

This is a follow up to PR #52.