### PR TITLE
Implement cljs version of ordered-map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ pom.xml.asc
 target
 .lein*
 docs
+tests.edn
+.cljs_node_repl
+.cpcache
+.dir-locals.el
+.nrepl-port
+node_modules
+out
+package-lock.json
+package.json

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[ -d node_modules/ws ] || npm install ws
+
+clojure -A:test -M -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,7 @@
-{:paths ["src"],
- :deps {org.clojure/clojure {:mvn/version "1.10.3"}},
+{:paths ["src" "resources"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
  :aliases
- {:test {:extra-paths ["test"]}}}
+ {:test {:extra-paths ["test"]
+         :extra-deps {lambdaisland/kaocha {:mvn/version "RELEASE"}
+                      lambdaisland/kaocha-cljs {:mvn/version "RELEASE"}
+                      org.clojure/clojurescript {:mvn/version "RELEASE"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"],
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}},
+ :aliases
+ {:test {:extra-paths ["test"]}}}

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,2 +1,0 @@
-{ordered/set flatland.ordered.set/into-ordered-set
- ordered/map flatland.ordered.map/ordered-map}

--- a/src/data_readers.cljc
+++ b/src/data_readers.cljc
@@ -1,0 +1,2 @@
+{ordered/set flatland.ordered.set/into-ordered-set
+ ordered/map flatland.ordered.map/ordered-map-reader}

--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -206,3 +206,8 @@ assoc'ed for the first time. Supports transient."
 (defmethod print-method OrderedMap [o ^java.io.Writer w]
   (.write w "#ordered/map ")
   (print-method (seq o) w))
+
+(defn ordered-map-reader [coll]
+  (if (some-> (resolve 'cljs.env/*compiler*) deref)
+    `(ordered-map ~(vec coll))
+    (ordered-map coll)))

--- a/src/flatland/ordered/map.cljs
+++ b/src/flatland/ordered/map.cljs
@@ -6,12 +6,14 @@
   (pr-sequential-writer
    writer
    (fn [k w opts]
+     (-write w \[)
      (-write w (pr-str k))
      (-write w \space)
-     (-write w (pr-str (get kvs k))))
+     (-write w (pr-str (get kvs k)))
+     (-write w \]))
    ;; Printing with square brackets so that we can define a data_reader that
    ;; preserves order.
-   "[" ", " "]"
+   "(" " " ")"
    opts
    ks))
 
@@ -81,6 +83,11 @@
     (when (seq ks)
       (map #(-find kvs %) ks)))
 
+  IReversible
+  (-rseq [this]
+    (when (seq ks)
+      (map #(-find kvs %) (rseq ks))))
+
   ICounted
   (-count [this] (count kvs))
 
@@ -128,9 +135,15 @@
            (.-kvs that)
            that)))
 
-(defn ordered-map [& kvs]
-  (OrderedMap. (apply hash-map kvs)
-               (mapv first (partition 2 kvs))))
+(def ^:private empty-ordered-map (OrderedMap. {} []))
+
+(defn ordered-map
+  ([]
+   empty-ordered-map)
+  ([coll]
+   (into empty-ordered-map coll))
+  ([k v & kvs]
+   (apply assoc empty-ordered-map k v kvs)))
 
 (comment
   (ordered-map :foo 123 :bar 456)

--- a/src/flatland/ordered/map.cljs
+++ b/src/flatland/ordered/map.cljs
@@ -11,8 +11,6 @@
      (-write w \space)
      (-write w (pr-str (get kvs k)))
      (-write w \]))
-   ;; Printing with square brackets so that we can define a data_reader that
-   ;; preserves order.
    "(" " " ")"
    opts
    ks))

--- a/src/flatland/ordered/map.cljs
+++ b/src/flatland/ordered/map.cljs
@@ -1,0 +1,191 @@
+(ns flatland.ordered.map)
+
+(declare equiv-impl)
+
+(defn print-ordered-map [writer kvs ks opts]
+  (pr-sequential-writer
+   writer
+   (fn [k w opts]
+     (-write w (pr-str k))
+     (-write w \space)
+     (-write w (pr-str (get kvs k))))
+   ;; Printing with square brackets so that we can define a data_reader that
+   ;; preserves order.
+   "[" ", " "]"
+   opts
+   ks))
+
+(deftype OrderedMap [kvs ks]
+  Object
+  (toString [this] (pr-str* this))
+  (equiv [this that] (equiv-impl kvs that))
+
+  ;; js/map interface
+  (keys [this] (es6-iterator ks))
+  (entries [this] (es6-entries-iterator (seq kvs)))
+  (values [this] (es6-iterator (vals kvs)))
+  (has [this k] (not (nil? (.get kvs k))))
+  (get [this k] (.get kvs k))
+  (forEach [this f]
+    (doseq [k ks]
+      (f k (get kvs k) this)))
+  (forEach [this f use-as-this]
+    (doseq [k ks]
+      (.call f use-as-this k (get kvs k) this)))
+
+  ;; js fallbacks
+  (key_set   [this] (to-array (keys kvs)))
+  (entry_set [this] (to-array (map to-array kvs)))
+  (value_set [this] (to-array (map val kvs)))
+
+  ICloneable
+  (-clone [_] (OrderedMap. kvs ks))
+
+  ;; IIterable
+  ;; (-iterator [_] )
+
+  IWithMeta
+  (-with-meta [this new-meta]
+    (if (identical? (meta kvs) new-meta)
+      this
+      (OrderedMap. (with-meta kvs new-meta) ks)))
+
+  IMeta
+  (-meta [this] (meta kvs))
+
+  ICollection
+  (-conj [coll entry]
+    (if (vector? entry)
+      (OrderedMap. (conj kvs entry) (if (contains? kvs (-nth entry 0))
+                                      ks
+                                      (conj ks (-nth entry 0))))
+      (OrderedMap. (conj kvs entry) (into ks
+                                          (comp (map #(-nth % 0))
+                                                (remove #(contains? kvs %)))
+                                          entry))))
+
+  IEmptyableCollection
+  (-empty [this]
+    (if (seq ks)
+      (OrderedMap. (-empty kvs) [])
+      this))
+
+  IEquiv
+  (-equiv [this that] (equiv-impl kvs that))
+
+  IHash
+  (-hash [_] (hash kvs))
+
+  ISeqable
+  (-seq [this]
+    (when (seq ks)
+      (map #(-find kvs %) ks)))
+
+  ICounted
+  (-count [this] (count kvs))
+
+  ILookup
+  (-lookup [this attr]           (-lookup kvs attr))
+  (-lookup [this attr not-found] (-lookup kvs attr not-found))
+
+  IAssociative
+  (-assoc [coll k v]
+    (OrderedMap. (assoc kvs k v) (if (contains? kvs k)
+                                   ks
+                                   (conj ks k))))
+  (-contains-key? [this k]
+    (contains? kvs k))
+
+  IFind
+  (-find [this k]
+    (-find kvs k))
+
+  IMap
+  (-dissoc [this k]
+    (if (contains? kvs k)
+      (OrderedMap. (dissoc kvs k) (into [] (remove #{k}) ks))
+      this))
+
+  IKVReduce
+  (-kv-reduce [coll f init]
+    (reduce
+     (fn [acc k]
+       (f acc k (get kvs k)))
+     init
+     ks))
+
+  IFn
+  (-invoke [this k] (kvs k))
+  (-invoke [this k not-found] (kvs k not-found))
+
+  IPrintWithWriter
+  (-pr-writer [_ writer opts]
+    (-write writer "#ordered/map ")
+    (print-ordered-map writer kvs ks opts)))
+
+(defn equiv-impl [kvs that]
+  (= kvs (if (instance? OrderedMap that)
+           (.-kvs that)
+           that)))
+
+(defn ordered-map [& kvs]
+  (OrderedMap. (apply hash-map kvs)
+               (mapv first (partition 2 kvs))))
+
+(comment
+  (ordered-map :foo 123 :bar 456)
+  ;; => #ordered/map [:foo 123, :bar 456]
+
+  (conj (ordered-map :foo 123 :bar 456) [:baz 123])
+  ;; => #ordered/map [:foo 123, :bar 456, :baz 123]
+
+  (assoc (ordered-map :foo 123 :bar 456)
+         :baz 123
+         :baq 999)
+  ;; => #ordered/map [:foo 123, :bar 456, :baz 123, :baq 999]
+
+  (merge (ordered-map :foo 123 :bar 456)
+         {:baz 123
+          :baq 999})
+  ;; => #ordered/map [:foo 123, :bar 456, :baz 123, :baq 999]
+
+  (= (ordered-map :foo 123 :bar 456 :baz 123)
+     {:foo 123 :bar 456 :baz 123})
+  ;; => true
+
+  (= {:foo 123 :bar 456 :baz 123}
+     (ordered-map :foo 123 :bar 456 :baz 123))
+  ;; => true
+
+  (map? (ordered-map :foo 123 :bar 456 :baz 123))
+  ;; => true
+
+  (empty (ordered-map :foo 123 :bar 456 :baz 123))
+  ;; => #ordered/map []
+
+  (ordered-map)
+  ;; => #ordered/map []
+
+  (seq (ordered-map))
+  ;; => nil
+
+  (reduce conj [] (ordered-map :foo 123 :bar 456 :baz 123))
+  ;; => [[:foo 123] [:bar 456] [:baz 123]]
+
+  (keys (ordered-map :foo 123 :bar 456 :baz 123))
+  ;; => (:foo :bar :baz)
+
+  (vals (ordered-map :foo 123 :bar 456 :baz 789))
+  ;; => (123 456 789)
+
+  (meta (with-meta (ordered-map) {:foo :bar}))
+  ;; => {:foo :bar}
+
+  (-> (ordered-map)
+      (assoc-in [:foo :bar] 1)
+      (assoc-in [:foo :baz] 2))
+
+  (into (ordered-map) [[:foo 1] [:bar 2] [:foo 3]])
+  ;; #ordered/map [:foo 3, :bar 2]
+
+  )

--- a/test/flatland/ordered/map_test.cljc
+++ b/test/flatland/ordered/map_test.cljc
@@ -5,8 +5,6 @@
                :cljs [cljs.reader :as reader]))
   #?(:clj (:import flatland.ordered.map.OrderedMap)))
 
-#_(read-string "#ordered/map ([1 9] [3 4] [5 6] [7 8])")
-
 #?(:cljs
    (defn read-string [s]
      (reader/read-string {:readers {'ordered/map ordered-map}} s)))

--- a/test/flatland/ordered/map_test.cljc
+++ b/test/flatland/ordered/map_test.cljc
@@ -1,28 +1,36 @@
 (ns flatland.ordered.map-test
-  (:use clojure.test
-        [flatland.ordered.map :only [ordered-map]]
-        [flatland.ordered.common :only [compact]])
-  (:import flatland.ordered.map.OrderedMap))
+  (:require [clojure.test :refer [deftest testing is are]]
+            [flatland.ordered.map :refer [#?(:cljs OrderedMap) ordered-map]]
+            #?(:clj [flatland.ordered.common :refer [compact]]
+               :cljs [cljs.reader :as reader]))
+  #?(:clj (:import flatland.ordered.map.OrderedMap)))
+
+#_(read-string "#ordered/map ([1 9] [3 4] [5 6] [7 8])")
+
+#?(:cljs
+   (defn read-string [s]
+     (reader/read-string {:readers {'ordered/map ordered-map}} s)))
 
 (deftest implementations
   (let [basic (ordered-map)]
-    (testing "Interfaces marked as implemented"
-      (are [class] (instance? class basic)
-          clojure.lang.IPersistentMap
-          clojure.lang.IPersistentCollection
-          clojure.lang.Counted
-          clojure.lang.Associative
-          java.util.Map))
+    #?(:clj
+       (testing "Interfaces marked as implemented"
+         (are [class] (instance? class basic)
+           clojure.lang.IPersistentMap
+           clojure.lang.IPersistentCollection
+           clojure.lang.Counted
+           clojure.lang.Associative
+           java.util.Map)))
     (testing "Behavior smoke testing"
       (testing "Most operations don't change type"
-        (are [object] (= (class object) (class basic))
-             (conj basic [1 2])
-             (assoc basic 1 2)
-             (into basic {1 2})))
+        (are [object] (= (type object) (type basic))
+          (conj basic [1 2])
+          (assoc basic 1 2)
+          (into basic {1 2})))
       (testing "Seq-oriented operations return nil when empty"
         (are [object] (nil? object)
-             (seq basic)
-             (rseq basic)))
+          (seq basic)
+          (rseq basic)))
       (testing "Metadata"
         (is (nil? (seq (meta basic))))
         (is (= 10 (-> basic
@@ -124,58 +132,60 @@
       (is (= {:a 1 :b 2 :c 3 :d 4} (conj m {:d 4}))))
     (testing "(conj m nil) returns m"
       (are [x] (= m x)
-           (conj m nil)
-           (merge m ())
-           (into m ()))))
+        (conj m nil)
+        (merge m ())
+        (into m ()))))
   (let [m (ordered-map :a '("spark") :b '("flare" "bolt"))]
     (testing "assoc replaces values if not identical?"
       (is (vector? (-> m
-                      (update-in [:a] vec)
-                      (get :a)))))))
+                       (update-in [:a] vec)
+                       (get :a)))))))
 
-(deftest object-features
-  (let [m (ordered-map 'a 1 :b 2)]
-    (is (= "{a 1, :b 2}" (str m)))))
+#?(:clj
+   (deftest object-features
+     (let [m (ordered-map 'a 1 :b 2)]
+       (is (= "{a 1, :b 2}" (str m))))))
 
-(deftest transient-support
-  (let [m (ordered-map {1 2 7 8})]
-    (testing "Basic transient conj!"
-      (let [t (transient m)
-            t (conj! t [3 4])
-            t (conj! t [3 4])
-            p (persistent! t)]
-        (is (= p (conj m [3 4])))))
-    (testing "Transients still keep order"
-      (let [t (transient m)
-            t (assoc! t 0 1)
-            p (persistent! t)]
-        (is (= (concat (seq m) '([0 1]))
-               (seq p)))))
-    (testing "Transients can overwrite existing entries"
-      (let [t (transient m)
-            t (assoc! t 1 5)
-            p (persistent! t)]
-        (is (= p (assoc m 1 5)))))
-    (testing "Transients can dissoc!"
-      (let [k (key (first m))
-            t (transient m)
-            t (dissoc! t k)]
-        (is (= (persistent! t)
-               (dissoc m k)))))
-    (testing "Can't edit transient after calling persistent!"
-      (let [more [[:a 1] [:b 2]]
-            t (transient m)
-            t (reduce conj! t more)
-            p (persistent! t)]
-        (is (thrown? Throwable (assoc! t :c 3)))
-        (is (= (into m more) p))))
-    (testing "Transients are never equal to other objects"
-      (let [[t1 t2 :as ts] (repeatedly 2 #(transient m))
-            holder (apply hash-set ts)]
-        (is (not= t1 t2))
-        (is (= (count ts) (count holder)))
-        (are [t] (= t (holder t))
-             t1 t2)))))
+#?(:clj
+   (deftest transient-support
+     (let [m (ordered-map {1 2 7 8})]
+       (testing "Basic transient conj!"
+         (let [t (transient m)
+               t (conj! t [3 4])
+               t (conj! t [3 4])
+               p (persistent! t)]
+           (is (= p (conj m [3 4])))))
+       (testing "Transients still keep order"
+         (let [t (transient m)
+               t (assoc! t 0 1)
+               p (persistent! t)]
+           (is (= (concat (seq m) '([0 1]))
+                  (seq p)))))
+       (testing "Transients can overwrite existing entries"
+         (let [t (transient m)
+               t (assoc! t 1 5)
+               p (persistent! t)]
+           (is (= p (assoc m 1 5)))))
+       (testing "Transients can dissoc!"
+         (let [k (key (first m))
+               t (transient m)
+               t (dissoc! t k)]
+           (is (= (persistent! t)
+                  (dissoc m k)))))
+       (testing "Can't edit transient after calling persistent!"
+         (let [more [[:a 1] [:b 2]]
+               t (transient m)
+               t (reduce conj! t more)
+               p (persistent! t)]
+           (is (thrown? Throwable (assoc! t :c 3)))
+           (is (= (into m more) p))))
+       (testing "Transients are never equal to other objects"
+         (let [[t1 t2 :as ts] (repeatedly 2 #(transient m))
+               holder (apply hash-set ts)]
+           (is (not= t1 t2))
+           (is (= (count ts) (count holder)))
+           (are [t] (= t (holder t))
+             t1 t2))))))
 
 (deftest print-and-read-ordered
   (let [s (ordered-map 1 2, 3 4, 5 6, 1 9, 7 8)]
@@ -186,34 +196,38 @@
       (is (= '([1 9] [3 4] [5 6] [7 8])
              (seq o))))))
 
-(deftest print-read-eval-ordered
-  (is (= (pr-str (eval (read-string "#ordered/map[[:a 1] [:b 2]]")))
-         "#ordered/map ([:a 1] [:b 2])"))
-  (is (= (pr-str (eval (read-string "#ordered/map[[1 2] [3 4] [5 6] [1 9] [7 8]]")))
-         "#ordered/map ([1 9] [3 4] [5 6] [7 8])")))
+#?(:clj
+   (deftest print-read-eval-ordered
+     (is (= (pr-str (eval (read-string "#ordered/map[[:a 1] [:b 2]]")))
+            "#ordered/map ([:a 1] [:b 2])"))
+     (is (= (pr-str (eval (read-string "#ordered/map[[1 2] [3 4] [5 6] [1 9] [7 8]]")))
+            "#ordered/map ([1 9] [3 4] [5 6] [7 8])"))))
 
-(deftest compacting
-  (let [m1 (ordered-map :a 1 :b 2 :c 3)
-        m2 (dissoc m1 :b)
-        m3 (compact m2)
-        m4 (dissoc m3 :c)]
-    (is (= m2 (ordered-map :a 1 :c 3)))
-    (is (= m3 m2))
-    (is (= m4 (ordered-map :a 1)))))
+#?(:clj
+   (deftest compacting
+     (let [m1 (ordered-map :a 1 :b 2 :c 3)
+           m2 (dissoc m1 :b)
+           m3 (compact m2)
+           m4 (dissoc m3 :c)]
+       (is (= m2 (ordered-map :a 1 :c 3)))
+       (is (= m3 m2))
+       (is (= m4 (ordered-map :a 1))))))
 
-(deftest same-hash
-  (let [m1 (ordered-map :a 1 :b 2 :c 3)
-        m2 (hash-map :a 1 :b 2 :c 3)
-        m3 (array-map :a 1 :b 2 :c 3)]
-    (is (= (hash m1) (hash m2) (hash m3)))
-    (is (= (.hashCode m1) (.hashCode m2) (.hashCode m3)))
-    (is (= (hash (ordered-map)) (hash (hash-map)) (hash (array-map))))
-    (is (= (.hashCode (ordered-map)) (.hashCode (hash-map)) (.hashCode (array-map))))))
+#?(:clj
+   (deftest same-hash
+     (let [m1 (ordered-map :a 1 :b 2 :c 3)
+           m2 (hash-map :a 1 :b 2 :c 3)
+           m3 (array-map :a 1 :b 2 :c 3)]
+       (is (= (hash m1) (hash m2) (hash m3)))
+       (is (= (.hashCode m1) (.hashCode m2) (.hashCode m3)))
+       (is (= (hash (ordered-map)) (hash (hash-map)) (hash (array-map))))
+       (is (= (.hashCode (ordered-map)) (.hashCode (hash-map)) (.hashCode (array-map)))))))
 
-(deftest nil-hash-code-npe
-  ;; No assertions here; just check that it doesn't NPE
-  ;; See: https://github.com/amalloy/ordered/issues/27
-  (are [contents] (.hashCode (ordered-map contents))
-    [[nil :a]]
-    [[:a nil]]
-    [[nil nil]]))
+#?(:clj
+   (deftest nil-hash-code-npe
+     ;; No assertions here; just check that it doesn't NPE
+     ;; See: https://github.com/amalloy/ordered/issues/27
+     (are [contents] (.hashCode (ordered-map contents))
+       [[nil :a]]
+       [[:a nil]]
+       [[nil nil]])))

--- a/test/flatland/ordered/performance_test.clj
+++ b/test/flatland/ordered/performance_test.clj
@@ -1,14 +1,14 @@
 (ns flatland.ordered.performance-test
   (:use clojure.test))
 
-(deftest reflection
-#_  (binding [*warn-on-reflection* true]
-    (are [ns-sym] (= ""
-                     (with-out-str
-                       (binding [*err* *out*]
-                         (require :reload ns-sym))))
-         ;; Order of the below is IMPORTANT. set depends on map, and if you
-         ;; reload map *after* reloading set, then set refers to classes that
-         ;; don't exist anymore, and all kinds of bad stuff happens
-         ;; (in this test and others)
-         'ordered.map 'ordered.set)))
+(deftest ^:kaocha/pending reflection
+  #_(binding [*warn-on-reflection* true]
+      (are [ns-sym] (= ""
+                       (with-out-str
+                         (binding [*err* *out*]
+                           (require :reload ns-sym))))
+        ;; Order of the below is IMPORTANT. set depends on map, and if you
+        ;; reload map *after* reloading set, then set refers to classes that
+        ;; don't exist anymore, and all kinds of bad stuff happens
+        ;; (in this test and others)
+        'ordered.map 'ordered.set)))

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,6 @@
+#kaocha/v1
+{:tests [{:id :clj}
+         {:id :cljs
+          :type :kaocha.type/cljs}]
+ :plugins [:notifier :print-invocations :hooks]
+ :kaocha.hooks/pre-load [(fn [t] (require (quote flatland.ordered.map)) t)]}


### PR DESCRIPTION
In a case of parallel evolution we wrote this as a utility in a project we are working on with the Nextjournal folks, unaware of this project. We only wrote the cljs version, and it seems this project only has a clj version, so that works out well.

This *only* implements `ordered-map` at the moment, so no transient map or sets. Still I assume this may already be useful for some, and can help as a guide to implement the rest. We used Datascript's `entity` implementation as a guide for which protocols to implement.

Partially addresses #43 .