### PR TITLE
[Fix #62] Remove support for Clojure prior to 1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,6 @@ commands:
     description: "Run tests"
     steps:
       - run:
-          name: Run JVM tests with clojure 1.6
-          command: |
-            lein with-profile +1.6 test
-      - run:
-          name: Run JVM tests with clojure 1.7
-          command: |
-            lein with-profile +1.7 test
-      - run:
           name: Run JVM tests with clojure 1.8
           command: |
             lein with-profile +1.8 test

--- a/project.clj
+++ b/project.clj
@@ -3,16 +3,14 @@
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :description "Pure-clojure implementation of ruby's ordered hash and set types - instead of sorting by key, these collections retain insertion order."
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :aliases {"testall" ["with-profile" "+1.6:+1.7:+1.8:+1.9:+1.10.0:+1.10.1" "test"]
-            "depsall" ["with-profile" "+1.6:+1.7:+1.8:+1.9:+1.10.0:+1.10.1" "deps"]}
+  :dependencies [[org.clojure/clojure "1.10.1"]]
+  :aliases {"testall" ["with-profile" "+1.8:+1.9:+1.10.0:+1.10.1" "test"]
+            "depsall" ["with-profile" "+1.8:+1.9:+1.10.0:+1.10.1" "deps"]}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :profiles {:1.10.1 {:dependencies [[org.clojure/clojure "1.10.1"]]}
              :1.10.0 {:dependencies [[org.clojure/clojure "1.10.0"]]}
-             :1.9  {}
+             :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              ;; Not required except for benchmarks.
              :dev {:dependencies [[ordered-collections "0.4.2"]]} })


### PR DESCRIPTION
Tests are failing for Clojure versions prior to 1.8. Rather than
trying to fix the code (or the tests), let's just say we don't support
Clojure prior to 1.8