### PR TITLE
Use private not-found var

### DIFF
--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -154,16 +154,17 @@ sorted in the order that keys are added. assoc'ing a key that is
 already in an ordered map leaves its order unchanged. dissoc'ing a
 key and then later assoc'ing it puts it at the end, as if it were
 assoc'ed for the first time. Supports transient."
-  (^OrderedMap [] empty-ordered-map)
-  (^OrderedMap [coll]
+  ([] empty-ordered-map)
+  ([coll]
      (into empty-ordered-map coll))
-  (^OrderedMap [k v & more]
+  ([k v & more]
      (apply assoc empty-ordered-map k v more)))
 
 ;; contains? is broken for transients. we could define a closure around a gensym
 ;; to use as the not-found argument to a get, but deftype can't be a closure.
 ;; instead, we pass `this` as the not-found argument and hope nobody makes a
 ;; transient contain itself.
+
 (deftype TransientOrderedMap [^{:unsynchronized-mutable true, :tag ITransientMap} backing-map,
                               ^{:unsynchronized-mutable true, :tag ITransientVector} order]
   ITransientMap

--- a/src/flatland/ordered/map.clj
+++ b/src/flatland/ordered/map.clj
@@ -26,6 +26,8 @@
 
 (declare transient-ordered-map)
 
+(def ^:private not-found (gensym "flatland.ordered.map/not-found"))
+
 (deftype OrderedMap [^clojure.lang.IPersistentMap backing-map
                      ^clojure.lang.IPersistentVector order]
 
@@ -42,8 +44,8 @@
                           (= (.val e) (.get ^Map other k)))))
                  (.seq this))))
   (entryAt [this k]
-    (let [v (get this k ::not-found)]
-      (when (not= v ::not-found)
+    (let [v (get this k not-found)]
+      (when (not= v not-found)
         (MapEntry. k v))))
   (valAt [this k]
     (.valAt this k nil))
@@ -152,17 +154,16 @@ sorted in the order that keys are added. assoc'ing a key that is
 already in an ordered map leaves its order unchanged. dissoc'ing a
 key and then later assoc'ing it puts it at the end, as if it were
 assoc'ed for the first time. Supports transient."
-  ([] empty-ordered-map)
-  ([coll]
+  (^OrderedMap [] empty-ordered-map)
+  (^OrderedMap [coll]
      (into empty-ordered-map coll))
-  ([k v & more]
+  (^OrderedMap [k v & more]
      (apply assoc empty-ordered-map k v more)))
 
 ;; contains? is broken for transients. we could define a closure around a gensym
 ;; to use as the not-found argument to a get, but deftype can't be a closure.
 ;; instead, we pass `this` as the not-found argument and hope nobody makes a
 ;; transient contain itself.
-
 (deftype TransientOrderedMap [^{:unsynchronized-mutable true, :tag ITransientMap} backing-map,
                               ^{:unsynchronized-mutable true, :tag ITransientVector} order]
   ITransientMap

--- a/test/flatland/ordered/map_test.cljc
+++ b/test/flatland/ordered/map_test.cljc
@@ -138,7 +138,10 @@
     (testing "assoc replaces values if not identical?"
       (is (vector? (-> m
                        (update-in [:a] vec)
-                       (get :a)))))))
+                       (get :a))))))
+  (testing "Can't store the not-found value"
+    (let [m (ordered-map :a :flatland.ordered.map/not-found)]
+      (is (some? (find m :a))))))
 
 #?(:clj
    (deftest object-features


### PR DESCRIPTION
Problem: When determining if a key exists in the backing map, we rely on matching the value against `:flatland.ordered.map/not-found`, which _probably_ won't be in backing map but could. By relying on a derivable value, hard to discover bugs can sneak in.

Potential solutions:
1) Leave as-is. Easiest, _probably_ won't break anything.
2) Use a more complicated keyword. Further decreases the likelihood of a match.
3) Create a gensym within the function. Impossible to derive, but requires creation on every call which is slow.
4) Create a private var that holds a stable gensym. Impossible to derive, quite fast.
5) Create a private Java Object. Impossible to derive, quite fast, less meaningful than gensym.

Chosen solution: I went with 4, which combines the meaningful information of the original namespaced keyword with a unique gensym symbol.