### PR TITLE
Fix NPE in ordered-set

### DIFF
--- a/src/flatland/ordered/set.clj
+++ b/src/flatland/ordered/set.clj
@@ -56,7 +56,7 @@
   (toString [this]
     (str "#{" (clojure.string/join " " (map str this)) "}"))
   (hashCode [this]
-    (reduce + (map #(.hashCode ^Object %) (.seq this))))
+    (reduce + (keep #(when % (.hashCode ^Object %)) (.seq this))))
   (equals [this other]
     (or (identical? this other)
         (and (instance? Set other)

--- a/test/flatland/ordered/set_test.clj
+++ b/test/flatland/ordered/set_test.clj
@@ -160,11 +160,14 @@
     (is (= (hash m1) (hash m2)))
     (is (= (.hashCode m1) (.hashCode m2)))
     (is (= (hash (ordered-set)) (hash (hash-set))))
-    (is (= (.hashCode (ordered-set)) (.hashCode (hash-set))))))
+    (is (= (.hashCode (ordered-set)) (.hashCode (hash-set))))
+    (is (= (hash (ordered-set nil)) (hash (hash-set nil))))
+    (is (= (.hashCode (ordered-set nil)) (.hashCode (hash-set nil))))
+    (is (= (.hashCode (ordered-set nil :a {:b nil})) (.hashCode (hash-set nil :a {:b nil}))))))
 
 (deftest nil-hash-code-npe
   ;; No assertions here; just check that it doesn't NPE
   ;; See: https://github.com/amalloy/ordered/issues/27
-  (are [contents] (.hashCode (ordered-set contents))
+  (are [contents] (.hashCode (apply ordered-set contents))
     [nil]
     [nil :a]))


### PR DESCRIPTION
I fixed the existing `flatland.ordered.set-test/nil-hash-code-npe` test as it was incorrectly written and never actually checked that ordered sets can contain nulls. Oops!

Closes https://github.com/clj-commons/ordered/issues/73