### PR TITLE
Remove 'resolve' from ordered set

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ A release with known breaking changes is marked with:
 
 === Added
 
+* Remove use of `resolve` in ordered-set. https://github.com/clj-commons/ordered/issues/71[#71]
 * Added ClojureScript support for `ordered-set`: https://github.com/clj-commons/ordered/issues/66[#66]
 (thanks, https://github.com/marksto[@marksto]!)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Remove use of `resolve` in ordered-set. [#71](https://github.com/clj-commons/ordered/issues/71)
+
 ## 1.15.12 - 2024-05-13
 
-* Fix NPE when hashing ordered-set that contain `nil`.
+* Fix NPE when hashing ordered-set that contain `nil`. [#73](https://github.com/clj-commons/ordered/issues/73)
 
 ## 1.15.11 - 2023-03-26
 

--- a/src/flatland/ordered/set.clj
+++ b/src/flatland/ordered/set.clj
@@ -9,13 +9,6 @@
 
 (declare transient-ordered-set)
 
-;; We could use compile-if technique here, but hoping to avoid
-;; an AOT issue using this way instead.
-(def hasheq-ordered-set
-  (or (resolve 'clojure.core/hash-unordered-coll)
-      (fn old-hasheq-ordered-set [^Seqable s]
-        (reduce + (map hash (.seq s))))))
-
 (deftype OrderedSet [^clojure.lang.IPersistentMap k->i
                      ^clojure.lang.IPersistentVector i->k]
   IPersistentSet
@@ -66,7 +59,7 @@
 
   IHashEq
   (hasheq [this]
-    (hasheq-ordered-set this))
+    (hash-unordered-coll this))
   
   Set
   (iterator [this]

--- a/src/flatland/ordered/set.clj
+++ b/src/flatland/ordered/set.clj
@@ -4,20 +4,13 @@
   (:import (clojure.lang IPersistentSet ITransientSet IEditableCollection
                          ITransientMap ITransientAssociative
                          ITransientVector IHashEq
-                         Associative Seqable SeqIterator Reversible IFn IObj)
+                         Associative SeqIterator Reversible IFn IObj)
            (java.io Writer)
            (java.util Set)))
 
 (set! *warn-on-reflection* true)
 
 (declare transient-ordered-set)
-
-;; We could use compile-if technique here, but hoping to avoid
-;; an AOT issue using this way instead.
-(def hasheq-ordered-set
-  (or (resolve 'clojure.core/hash-unordered-coll)
-      (fn old-hasheq-ordered-set [^Seqable s]
-        (reduce + (map hash (.seq s))))))
 
 (deftype OrderedSet [^clojure.lang.IPersistentMap k->i
                      ^clojure.lang.IPersistentVector i->k]
@@ -68,7 +61,7 @@
 
   IHashEq
   (hasheq [this]
-    (hasheq-ordered-set this))
+    (hash-unordered-coll this))
 
   Set
   (iterator [this]


### PR DESCRIPTION
See [#71](https://github.com/clj-commons/ordered/issues/71).

`clojure.core/hash-unordered-coll` has been around since 1.6 and ordered only supports 1.10+ so there's no need to check for its existence anymore.