### PR TITLE
bb tasks: add test-clj

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 * Docs
 ** While converting to AsiiDoc, restructured to separate User, Developer and Maintainer guide docs
 https://github.com/clj-commons/ordered/issues/81[#81]
+** Explicitly state that the minimum supported Clojure version is 1.10.3 https://github.com/clj-commons/ordered/issues/86[#86]
 
 == 1.15.12 - 2024-05-13
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,7 +1,9 @@
 {:min-bb-version "1.13.220"
  :paths ["script"]
  :deps {lread/status-line {:git/url "https://github.com/lread/status-line.git"
-                           :sha "eace48e2e0fcc65a3986d696fb0b910fa5790a1c"}}
+                           :sha "eace48e2e0fcc65a3986d696fb0b910fa5790a1c"}
+        version-clj/version-clj {:mvn/version "2.0.3"}
+        wevre/natural-compare {:mvn/version "0.0.10"}}
  :tasks {:requires ([clojure.string :as str]
                     [lread.status-line :as status])
          :enter (let [{:keys [name]} (current-task)] (status/line :head "TASK %s %s" name (str/join " " *command-line-args*)))
@@ -9,4 +11,5 @@
          :cli helper.cli/base-opts
 
          ;; commands
-         clean             {:exec-fn clean/task             :doc "delete all build work"}}}
+         clean             {:exec-fn clean/task             :doc "delete all build work"}
+         test-clj          {:exec-fn test-clj/task          :doc "run tests against a version of Clojure"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,26 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}}
  :aliases
- {:test {:extra-paths ["test"]
+ {;;
+  ;; Clojure versions we support (discovered by scripts by their clojure- prefix)
+  ;;
+  :clojure-1.10 {:override-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
+  :clojure-1.11 {:override-deps {org.clojure/clojure {:mvn/version "1.11.4"}}}
+  :clojure-1.12 {:override-deps {org.clojure/clojure {:mvn/version "1.12.6"}}}
+  ;; Candidate release is :clojure-pre-* (ex. clojure-pre-1.13.0) (if any)
+  :clojure-pre-1.13 {:override-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha6"}}}
+
+  ;;
+  ;; Test Runners
+  ;;
+  :test-common {:extra-paths ["test"]}
+
+  :clj-test-runner {:extra-deps {io.github.cognitect-labs/test-runner
+                                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                    :main-opts ["-m" "cognitect.test-runner"]}
+
+  ;; OLD: for reference only
+  :test {:extra-paths ["test"]
          :extra-deps {lambdaisland/kaocha {:mvn/version "RELEASE"}
                       lambdaisland/kaocha-cljs {:mvn/version "RELEASE"}
                       org.clojure/clojurescript {:mvn/version "RELEASE"}}}}}

--- a/doc/01-user-guide.adoc
+++ b/doc/01-user-guide.adoc
@@ -38,6 +38,9 @@ Include the following dependency in your `project.clj` file:
 `ordered` is a babashka built-in library.
 There is no project setup.
 
+== Supported Envs
+For usage from Clojure on the JVM, we support Clojure v1.10.3 and above.
+
 == Sets
 
 [source, clojure]

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -2,4 +2,43 @@
 :toclevels: 6
 :toc:
 
-Coming soon!
+== Prerequisites
+* Java JDK 1.8 or above (Clojure 1.13+ required JDK 17+)
+* Current Clojure CLI
+** Note that `ordered` itself supports Clojure v1.10.3 and above
+* Current Babashka
+
+== Babashka Tasks
+All scripts are written in Clojure and invoked via https://github.com/borkdude/babashka[babashka] tasks.
+This gives us a cross platform scripting language that is familiar, fun and consistent.
+
+To see all available tasks with a short description run:
+----
+bb tasks
+----
+
+To run a task, for example, the `test-clj` task:
+----
+bb test-clj
+----
+
+Usage help for a task is requested via `--help`, for example:
+----
+bb test-clj --help
+----
+
+Tasks are described throughout this document.
+
+=== Clean
+Sometimes you want to turf any local build work and caches, you can do so via:
+
+----
+bb clean
+----
+
+=== Unit tests
+Unit tests can be run locally on your dev box.
+Some tests require a specific os and jdk, you will see warnings if a test is skipped for your current environment.
+----
+bb test-clj
+----

--- a/script/helper/clojure_versions.clj
+++ b/script/helper/clojure_versions.clj
@@ -1,0 +1,42 @@
+(ns helper.clojure-versions
+  (:require [clojure.edn :as edn]
+            [version-clj.core :as version]
+            [wevre.natural-compare :as natural-compare]))
+
+(defn all
+  "Returns vector of maps with :version :alias :pre-release?"
+  []
+  (->> (slurp "deps.edn")
+       edn/read-string
+       :aliases
+       (keep (fn [[k v]]
+               (when-let [[_ prefix version] (re-find #"(clojure-pre-|clojure-)(.*)" (name k))]
+                 (if-let [mvn-version (get-in v [:override-deps 'org.clojure/clojure :mvn/version])]
+                   {:version version
+                    :mvn-version mvn-version
+                    :alias k
+                    :pre-release? (= "clojure-pre-" prefix)
+                    :min-jdk-major (if (version/newer-or-equal? mvn-version "1.13-alpha5") 17 8)}
+                   (throw (ex-info (str "failed to find mvn/version for alias " k) {}))))))
+       (sort-by :version natural-compare/natural-compare)
+       (into [])))
+
+(defn current-prod
+  "Returns current production release"
+  []
+  (->> (all)
+       (remove :pre-release?)
+       last))
+
+(defn lookup
+  "Retunrs :version :alias :pre-release? map for `version`"
+  [version]
+  (or (some #(when (= version (:version %)) %) (all))
+      (throw (ex-info (str "Clojure version not found: " version) {}))))
+
+(defn cli-opt [cli-clojure-versions]
+  {:clojure-version {:alias :v
+                     :coerce :string
+                     :desc "Test with Clojure"
+                     :enum cli-clojure-versions
+                     :default (first cli-clojure-versions)}})

--- a/script/helper/jdk.clj
+++ b/script/helper/jdk.clj
@@ -1,0 +1,19 @@
+(ns helper.jdk
+  (:require [helper.shell :as shell]))
+
+(defn version
+  "Returns jdk version and major version with appropriate conversion. (ex 1.8 returns major of 8)"
+  []
+  (let [raw-version (->> (shell/command {:err :string}
+                                        "java -version")
+                         :err
+                         (re-find #"version \"(.*)\"")
+                         last)
+        major-minor (->> raw-version
+                         (re-find #"(\d+)(?:\.(\d+))?.*")
+                         rest
+                         (map #(when % (Integer/parseInt %))))]
+    {:version raw-version
+     :major (if (= (first major-minor) 1)
+              (second major-minor)
+              (first major-minor))}))

--- a/script/helper/shell.clj
+++ b/script/helper/shell.clj
@@ -1,0 +1,30 @@
+(ns helper.shell
+  (:require [babashka.tasks :as tasks]
+            [clojure.pprint :as pprint]
+            [lread.status-line :as status]))
+
+(def default-opts {:error-fn
+                   (fn die-on-error [{{:keys [exit cmd]} :proc}]
+                               (status/die exit
+                                           "shell exited with %d for: %s"
+                                           exit
+                                           (with-out-str (pprint/pprint cmd))))})
+
+(defn command
+  "Thin wrapper on babashka.tasks/shell that on error, prints status error message and exits.
+  Automatically converts calls to clojure on Windows to call with powershell"
+  [cmd & args]
+  (let [[opts cmd args] (if (map? cmd)
+                          [cmd (first args) (rest args)]
+                          [nil cmd args])
+        opts (merge opts default-opts)]
+    (apply tasks/shell opts cmd args)))
+
+(defn clojure
+  "Wrap tasks/clojure for my loud error reporting treatment"
+  [& args]
+  (let [[opts args] (if (map? (first args))
+                      [(first args) (rest args)]
+                      [nil args])
+        opts (merge opts default-opts)]
+    (apply tasks/clojure opts args)))

--- a/script/test_clj.clj
+++ b/script/test_clj.clj
@@ -1,0 +1,26 @@
+(ns test-clj
+  (:require [helper.clojure-versions :as clojure-versions]
+            [helper.jdk :as jdk]
+            [helper.shell :as shell]
+            [lread.status-line :as status]))
+
+(defn run-unit-tests [{:keys [mvn-version alias] :as _clojure-version}]
+  (status/line :head (str "testing clojure source against clojure v" mvn-version))
+  (shell/command "clojure"
+                 (str "-M:test-common:clj-test-runner:" alias)))
+
+(def cli-clojure-versions (conj (mapv :version (clojure-versions/all)) "all"))
+
+(defn task
+  {:org.babashka/cli {:spec (clojure-versions/cli-opt cli-clojure-versions)}}
+  [{:keys [clojure-version]}]
+  (let [env-jdk-version (jdk/version)
+        clojure-versions (if (= "all" clojure-version)
+                             (clojure-versions/all)
+                             [(clojure-versions/lookup clojure-version)])]
+    (doseq [v clojure-versions]
+      (if (and (= "all" clojure-version)
+               (< (:major env-jdk-version) (:min-jdk-major v)))
+        (status/line :warn "Skipping testing clojure version %s\nIt requires min JDK %s, found JDK %s"
+                     (:mvn-version v) (:min-jdk-major v) (:version env-jdk-version))
+        (run-unit-tests v)))))


### PR DESCRIPTION
Clojure versions are automatically discovered from clojure-* deps.edn aliases. Can target one version or `all`.

I decided to use the cognitect test runner instead of kaocha.

Min Clojure version is now explicitly 1.10.3.

Closes #86
Contributes to #82