### PR TITLE
bb tasks: add dev-jvm & dev-cljs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ package-lock.json
 package.json
 .cache
 .eastwood
+.repl

--- a/bb.edn
+++ b/bb.edn
@@ -13,6 +13,8 @@
          ;; commands
          clean             {:exec-fn clean/task             :doc "delete all build work"}
          download-deps     {:exec-fn download-deps/task     :doc "bring down Clojure deps"}
+         dev-jvm           {:exec-fn dev-repl/dev-jvm       :doc "launch jvm nREPL for development"}
+         dev-cljs          {:exec-fn dev-repl/dev-cljs      :doc "launch cljs nREPL for development"}
          lint-kondo        {:exec-fn lint-kondo/task        :doc "lint with clj-kondo" }
          lint-eastwood     {:exec-fn lint-eastwood/task     :doc "lint with Eastwood"}
          test-clj          {:exec-fn test-clj/task          :doc "run tests against a version of Clojure"}

--- a/deps.edn
+++ b/deps.edn
@@ -16,6 +16,29 @@
   :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.12.145"}}}
 
   ;;
+  ;; REPL to support bb dev-jvm & dev-cljs tasks, see script/dev_repl.clj
+  ;;
+  :nrepl
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.7.0"}
+                cider/cider-nrepl {:mvn/version "0.62.2"}}
+   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]}
+
+  :nrepl/jvm
+  {:extra-deps {refactor-nrepl/refactor-nrepl {:mvn/version "3.14.0"}}
+   :jvm-opts ["-Djdk.attach.allowAttachSelf"]
+   :main-opts  ["-m" "nrepl.cmdline"
+                "--middleware" "[refactor-nrepl.middleware/wrap-refactor,cider.nrepl/cider-middleware]"
+                "-i"]}
+
+  :nrepl/cljs ;; note shadow-cljs does its own thing, this is for a REPL with
+              ;; support for plain old ClojureScript
+  {:extra-deps {cider/piggieback {:mvn/version "0.7.0"}}
+   :jvm-opts ["-Djdk.attach.allowAttachSelf"]
+   :main-opts ["-m" "nrepl.cmdline"
+               "--middleware" "[cider.nrepl/cider-middleware,cider.piggieback/wrap-cljs-repl]"
+               "-i"]}
+  
+  ;;
   ;; Linters
   ;;
   :clj-kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2026.08.04"}}

--- a/doc/02-developer-guide.adoc
+++ b/doc/02-developer-guide.adoc
@@ -37,6 +37,25 @@ bb test-clj --help
 
 Tasks are described throughout this document.
 
+=== REPLs
+
+To launch a nREPL server:
+
+----
+bb dev-jvm
+----
+
+From your IDE, cider connect clj to this REPL server.
+
+
+For a nREPL server that also includes ClojureScript support:
+
+----
+bb dev-cljs
+----
+
+From your IDE, cider connect cljs to this REPL server.
+
 === Clean
 Sometimes you want to turf any local build work and caches, you can do so via:
 
@@ -52,7 +71,7 @@ bb test-clj
 bb test-cljs
 ----
 
-== Checking for Outdated Dependencies
+=== Checking for Outdated Dependencies
 
 To see what new dependencies are available, run:
 ----

--- a/script/dev_repl.clj
+++ b/script/dev_repl.clj
@@ -1,0 +1,43 @@
+(ns dev-repl
+  (:require [babashka.process :as process]
+            [clojure.string :as str]
+            [helper.clojure-versions :as clojure-versions]
+            [lread.status-line :as status]))
+
+(defn- launch-repl [flavor {:keys [flowstorm host bind port]}]
+  (let [aliases (cond-> [(case flavor
+                           :cljs "nrepl/cljs:cljs"
+                           :jvm  "nrepl/jvm")]
+                  flowstorm (conj "flowstorm"))]
+    (status/line :head "Launching Clojure %s nREPL" (name flavor))
+    (when flowstorm
+      (status/line :detail "Flowstorm support is enabled"))
+    (process/exec "clj" (str "-M:" (:alias (clojure-versions/current-prod)) ":test-common:nrepl:" (str/join ":" aliases))
+                  "-h" host
+                  "-b" bind
+                  "-p" port)))
+
+(def cli-repl-opts {:spec {:host {:ref "<ADDR>"
+                                  :alias :h
+                                  :default "127.0.0.1"
+                                  :desc "Host address"}
+                           :bind {:ref "<ADDR>"
+                                  :alias :b
+                                  :default "127.0.0.1"
+                                  :desc "Bind address"}
+                           :port {:ref "<symbols>"
+                                  :coerce :int
+                                  :default 0
+                                  :alias :p
+                                  :desc "Port, 0 for auto-select"}}})
+
+;; Entry points
+(defn dev-jvm
+  {:org.babashka/cli cli-repl-opts}
+  [opts]
+  (launch-repl :jvm opts))
+
+(defn dev-cljs
+  {:org.babashka/cli cli-repl-opts}
+  [opts]
+  (launch-repl :cljs opts))


### PR DESCRIPTION
There are some warnings emitted on bb dev-cljs startup, like:
```
WARNING: Middleware #'cider.piggieback/wrap-cljs-repl is required by #'cider.nrepl/wrap-complete but is not present in middleware list.
```
But they don't seem to have a negative effect.

Contributes to #82